### PR TITLE
Fixed access to `data-` attributes using `event.currentTarget`.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@ Sweet Alert2 Asset Change Log
 
 ## 1.0.1 under development
 
-- no changes in this release.
+- Bug `PR-#8`: Fixed access to `data-` attributes using `event.currentTarget`. (@terabytesoftw)
 
 ## 1.0.0 May 15, 2023
 

--- a/src/js/sweetalert.js
+++ b/src/js/sweetalert.js
@@ -2,13 +2,13 @@
 function sweetAlertClickHandler(event) {
     event.preventDefault();
 
-    const cancelText = event.target.getAttribute('data-cancel-text') || 'Cancel';
-    const confirmText = event.target.getAttribute('data-confirm-text') || 'Accept';
-    const icon = event.target.getAttribute('data-icon') || 'question'; // Valor por defecto: 'question'
-    const message = event.target.getAttribute('data-message');
-    const method = event.target.getAttribute('data-method') || 'GET'; // Valor por defecto: 'GET'
-    const url = event.target.href;
-    const title = event.target.getAttribute('data-title') || 'Confirmation';
+    const cancelText = event.currentTarget.getAttribute('data-cancel-text') || 'No';
+    const confirmText = event.currentTarget.getAttribute('data-confirm-text') || 'Yes';
+    const icon = event.currentTarget.getAttribute('data-icon') || 'question';
+    const message = event.currentTarget.getAttribute('data-message');
+    const method = event.currentTarget.getAttribute('data-method') || 'GET';
+    const url = event.currentTarget.href;
+    const title = event.currentTarget.getAttribute('data-title') || 'Confirmation';
 
     Swal.fire(
         {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
